### PR TITLE
Add ability to restrict children.

### DIFF
--- a/polymorphic_tree/admin/parentadmin.py
+++ b/polymorphic_tree/admin/parentadmin.py
@@ -131,18 +131,21 @@ class PolymorphicMPTTParentModelAdmin(PolymorphicParentModelAdmin, MPTTModelAdmi
         return hasattr(node, 'get_absolute_url')
 
 
-    def can_have_children(self, node):
+    def can_have_children(self, node, child=None):
         """
         Define whether a node can have children.
         """
-        # Allow can_have_children to be either to be a property on the base class that always works.
-        if not node.can_have_children:
+        can_have_children = node.can_have_children
+        if not can_have_children:
             return False
 
-        # or a static variable declared on the class (avoids need for downcasted models).
-        NodeClass = node.get_real_instance_class()
-        return bool(NodeClass.can_have_children)
+        child_types = node.get_child_types()
 
+        # if child is None then we are just interested in boolean
+        # if we have a child we should check if it is allowed
+        return (can_have_children and (
+                child is None or len(child_types) == 0 or
+                child.polymorphic_ctype_id in child_types))
 
 
     # ---- Custom views ----
@@ -188,12 +191,22 @@ class PolymorphicMPTTParentModelAdmin(PolymorphicParentModelAdmin, MPTTModelAdmi
         except self.model.DoesNotExist as e:
             return HttpResponseNotFound(json.dumps({'action': 'reload', 'error': str(e[0])}), content_type='application/json')
 
-        if not self.can_have_children(target) and position == 'inside':
-            return HttpResponse(json.dumps({
-                'action': 'reject',
-                'moved_id': moved_id,
-                'error': _(u'Cannot place \u2018{0}\u2019 below \u2018{1}\u2019; a {2} does not allow children!').format(moved, target, target._meta.verbose_name)
-            }), content_type='application/json', status=409)  # Conflict
+        if position == 'inside':
+            error = None
+            if not self.can_have_children(target):
+                error = _(u'Cannot place \u2018{0}\u2019 below \u2018{1}\u2019;'
+                    u' a {2} does not allow children!').format(moved, target,
+                    target._meta.verbose_name)
+            elif not self.can_have_children(target, moved):
+                error = _(u'Cannot place \u2018{0}\u2019 below \u2018{1}\u2019;'
+                    u' a {2} does not allow {3} as a child!').format(moved,
+                    target, target._meta.verbose_name, moved._meta.verbose_name)
+            if error is not None:
+                return HttpResponse(json.dumps({
+                    'action': 'reject',
+                    'moved_id': moved_id,
+                    'error': error
+                }), content_type='application/json', status=409)  # Conflict
         if moved.parent_id != previous_parent_id:
             return HttpResponse(json.dumps({
                 'action': 'reload',

--- a/polymorphic_tree/models.py
+++ b/polymorphic_tree/models.py
@@ -2,13 +2,15 @@
 Model that inherits from both Polymorphic and MPTT.
 """
 from future.utils import with_metaclass
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
-from django.utils.six import integer_types
 from mptt.models import MPTTModel, MPTTModelBase, TreeForeignKey
 from polymorphic import PolymorphicModel
 from polymorphic.base import PolymorphicModelBase
 from polymorphic_tree.managers import PolymorphicMPTTModelManager
+
+from six import integer_types, string_types
 
 def _get_base_polymorphic_model(ChildModel):
     """
@@ -49,14 +51,23 @@ class PolymorphicTreeForeignKey(TreeForeignKey):
         elif isinstance(parent, integer_types):
             # TODO: Improve this code, it's a bit of a hack now because the base model is not known in the NodeTypePool.
             base_model = _get_base_polymorphic_model(model_instance.__class__)
-
-            # Get parent, TODO: needs to downcast here to read can_have_children.
             parent = base_model.objects.get(pk=parent)
         elif not isinstance(parent, PolymorphicMPTTModel):
             raise ValueError("Unknown parent value")
 
         if parent.can_have_children:
             return
+
+        can_have_children = parent.can_have_children
+        if can_have_children:
+            child_types = parent.get_child_types()
+            if (len(child_types) == 0 or
+                    model_instance.polymorphic_ctype_id in child_types):
+                return # child is allowed
+            raise ValidationError(
+                self.error_messages['child_not_allowed'].format(parent,
+                    parent._meta.verbose_name,
+                    model_instance._meta.verbose_name))
 
         raise ValidationError(self.error_messages['no_children_allowed'])
 
@@ -69,9 +80,57 @@ class PolymorphicMPTTModel(with_metaclass(PolymorphicMPTTModelBase, MPTTModel, P
 
     #: Whether the node type allows to have children.
     can_have_children = True
+    #: Allowed child types for this page.
+    child_types = []
+    # Cache child types using a class variable to ensure that get_child_types
+    # is run once per page class, per django initiation.
+    __child_types = {}
 
     # Django fields
     _default_manager = PolymorphicMPTTModelManager()
+
+    @property
+    def page_key(self):
+        """
+        A unique key for this page to ensure get_child_types is run once per
+        page.
+        """
+        return repr(self)
+
+    def get_child_types(self):
+        """
+        Get the allowed child types and convert them into content type ids.
+        This allows for the lookup of allowed children in the admin tree.
+        """
+        key = self.page_key
+        child_types = self._PolymorphicMPTTModel__child_types
+        if self.can_have_children and child_types.setdefault(key, None) is None:
+            new_children = []
+            iterator = iter(self.child_types)
+            for child in iterator:
+                if isinstance(child, string_types):
+                    child = str(child).lower()
+                    # write self to refer to self
+                    if child == 'self':
+                        ct_id = self.polymorphic_ctype_id
+                    else:
+                        # either the name of a model in this app
+                        # or the full app.model dot string
+                        # just like a foreign key
+                        try:
+                            app_label, model = child.rsplit('.', 1)
+                        except ValueError:
+                            app_label = self._meta.app_label
+                            model = child
+                        ct_id = ContentType.objects.get(app_label=app_label,
+                            model=model).id
+                else:
+                    # pass in a model class
+                    ct_id = ContentType.objects.get_for_model(child).id
+                new_children.append(ct_id)
+            child_types[key] = new_children
+        return child_types[key]
+
 
     class Meta:
         abstract = True

--- a/polymorphic_tree/templates/admin/polymorphic_tree/jstree_list_results.html
+++ b/polymorphic_tree/templates/admin/polymorphic_tree/jstree_list_results.html
@@ -46,7 +46,7 @@
    */
 
   var data = [{% adminlist_recursetree cl %}{% with is_leaf=node.is_leaf_node %}
-    {id: {{ node.pk }}, classes: 'nodetype-{{ node|real_model_name|lower }}', can_have_children: {{ node.can_have_children|yesno:'true,false' }}, label: '<div class="col-primary{% if is_leaf %} leaf{% endif %}"><div class="col first-column"><a href="{{ change_url }}"{% if cl.is_popup %} onclick="opener.dismissRelatedLookupPopup(window, {{ node.pk }}); return false;"{% endif %}>{{ first_column|escapejs }}</a></div></div>{% if other_columns %}<div class="col-metadata">{% for name, repr in other_columns %}<div class="col col-{{ name }}">{{ repr|escapejs }}</div>{% endfor %}</div>{% endif %}'{% if not is_leaf %},
+    {id: {{ node.pk }}, ct: {{ node.polymorphic_ctype_id }}, classes: 'nodetype-{{ ct.model|lower }}', can_have_children: {{ node.can_have_children|yesno:"true,false" }}, child_types: {% firstof node.get_child_types "[]" %}, label: '<div class="col-primary{% if is_leaf %} leaf{% endif %}"><div class="col first-column"><a href="{{ change_url }}"{% if cl.is_popup %} onclick="opener.dismissRelatedLookupPopup(window, {{ node.pk }}); return false;"{% endif %}>{{ first_column|escapejs }}</a></div></div>{% if other_columns %}<div class="col-metadata">{% for name, repr in other_columns %}<div class="col col-{{ name }}">{{ repr|escapejs }}</div>{% endfor %}</div>{% endif %}'{% if not is_leaf %},
      children: [ {{ children }}
      ]{% endif %}},{% endwith %}{% endadminlist_recursetree %}
     null  // for MSIE
@@ -64,9 +64,13 @@
     $div.append(contents);
   }
 
-  function onCanMoveTo(moved_node, target_node, position)
-  {
-    return ( target_node.can_have_children || position != 'inside' );
+  function onCanMoveTo(moved_node, target_node, position) {
+    var can_have_children = target_node.can_have_children;
+    var child_types = target_node.child_types;
+    if (can_have_children && child_types.length > 0){
+      can_have_children = jQuery.inArray(moved_node.ct, child_types) > -1;
+    }
+    return ( can_have_children || position != 'inside' );
   }
 
   var tree = jQuery("#js-result-list").tree({


### PR DESCRIPTION
Added child_types list.

Cache child types using a class variable to ensure that get_child_types is run
once per page class, per django initiation.

The list is list of values similar to those values accepted in a model
ForeignKey.

i.e. ["self", "app.Model", "Model", Model]
With "self" referring to the model on which can_have_children is defined.
"app.Model" is an app_label-model dot string.
"Model" is a model in the current app.
And the last is a Model class or Model instance.
